### PR TITLE
fix: ios theme pages cannot be rendered

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -16,7 +16,8 @@ const defaults = {
     main: true,
     pushState: true,
     pushStateSeparator: '!#',
-    pushStateRoot: null
+    pushStateRoot: null,
+    iosDynamicNavbar: false
   }
 }
 


### PR DESCRIPTION
Currently, if use dynamic navbar in ios-theme, pages cannot be rendered by following error:
![image](https://user-images.githubusercontent.com/4312154/30948197-e5256458-a3d3-11e7-83cf-1a1990426588.png)

It should be a framework7-vue issue, f7 executes  f7-router.forward before page is appended to window, so I turn off it for now and may submit a pr if figure it out.