### PR TITLE
fix: remove route name to make dynamic navbar useable

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -16,8 +16,7 @@ const defaults = {
     main: true,
     pushState: true,
     pushStateSeparator: '!#',
-    pushStateRoot: null,
-    iosDynamicNavbar: false
+    pushStateRoot: null
   }
 }
 

--- a/lib/templates/routes.js
+++ b/lib/templates/routes.js
@@ -16,7 +16,6 @@ function recursiveRoutes(routes, tab, components) {
     res += tab + '{\n'
     res += tab + '\tpath: ' + JSON.stringify(route.path) + ',\n'
     res += tab + '\tcomponent: ' + route._name
-    res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''
     res += (route.tabs) ? ',\n\t' + tab + 'tabs: ' + JSON.stringify(route.tabs) : ''
     res += '\n' + tab + '}' + (i + 1 === routes.length ? '' : ',\n')


### PR DESCRIPTION
[navigate](https://github.com/framework7io/Framework7/blob/v2/src/modules/router/navigate.js#L464-L468) will use `name` prior to `component` to load component, and the `name` way loading [here](https://github.com/framework7io/Framework7/blob/v2/src/modules/router/navigate.js#L400-L404) will directly forward to page instead of initializing component by `pageComponentLoader` firstly, so error occurred.
I think the `name` of `route` is unnecessary in project, so I remove it, @pi0 could you pls help to review the solution ?